### PR TITLE
Initial work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+coverage.txt

--- a/README.md
+++ b/README.md
@@ -1,2 +1,113 @@
-# go-chpr-logger
-Go logging with chpr conventions
+➤ Readme generated with godocdown
+
+This package implements our standard Logrus + Logentries + Sentry configuration.
+
+The package manages a singleton instance of logrus.Logger, initialized from
+environment variables.
+
+You will use it exactly as you would use logrus.
+
+
+### Examples
+
+Log an info:
+
+    WithFields(logger.Fields{
+    	"driverId": driverId,
+    	"rideId": rideId,
+    }).Info("Ride accepted")
+
+Log an info with a single field:
+
+    WithField("userId", userId).Info("User logged in")
+
+Log an error:
+
+    WithFields(logger.Fields{
+    	"event": event,
+    	"err": err
+    }).Error("Could not store ride end event")
+
+IMPORTANT: when logging an error or a warning, don't put an error you're not
+sure about the message as the message. The reason for that is that sentry uses
+the message to regroup similar events. If your library returns different
+messages for different occurrences of the same problem, you will flood your team
+with a lot of alerts for the same problem. Instead, put the error in the data.
+
+
+### Configuration
+
+SENTRY_DSN: If provided, warning and error logs will be sent to sentry.
+
+LOGGER_NAME - not yet implemented - The name of the logger.
+
+LOGGER_LEVEL - not yet implemented - The minimum level of the message to be
+actually logged. Possible values: "debug", "info", "warning", "error".
+
+LOGENTRIES_TOKEN - not yet implemented - If provided, logs will be sent to
+logentries.
+
+LOGSTASH_HOST - not yet implemented - If provided, logs will be sent to
+logstash.
+
+LOGSTASH_PORT - not yet implemented - Mandatory if LOGSTASH_HOST is provided.
+
+
+### Notes
+
+Methods that allow logging without context are not provided, in order to
+discourage logging without context.
+
+## Usage
+
+#### func  CreateLogger
+
+```go
+func CreateLogger() *logrus.Logger
+```
+Returns the already configured logrus.Logger singletton.
+
+Note: this instance is cached, so if the environment changes, you will need to
+call ReloadConfiguration() before calling this method.
+
+#### func  GetLogger
+
+```go
+func GetLogger() *logrus.Logger
+```
+Returns the already configured logrus.Logger singletton.
+
+Note: this instance is cached, so if the environment changes, you will need to
+call ReloadConfiguration() before calling this method.
+
+#### func  ReloadConfiguration
+
+```go
+func ReloadConfiguration()
+```
+Reloads configuration from the environment. Mostly useful for tests.
+
+#### func  WithField
+
+```go
+func WithField(key string, value interface{}) *logrus.Entry
+```
+Shorthand for GetLogger().WithField(fields). Use instead of logrus.WithField.
+
+#### func  WithFields
+
+```go
+func WithFields(fields Fields) *logrus.Entry
+```
+Shorthand for GetLogger().WithFields(fields). Use instead of logrus.WithFields.
+
+#### type Fields
+
+```go
+type Fields logrus.Fields
+```
+
+Alias for the logrus.Fields
+
+This will allow most of our code to not directly depend on logrus, making it
+much easier if we have to switch to another logger later.

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,21 @@
+machine:
+  services:
+    - docker
+  environment:
+    GOPATH: /home/ubuntu/.go_workspace
+    IMPORT_PATH: github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+
+general:
+  build_dir: ../.go_workspace/src/$IMPORT_PATH
+
+checkout:
+  post:
+    - mkdir -p "$GOPATH/src/$IMPORT_PATH"
+    - rsync -azC --delete $HOME/$CIRCLE_PROJECT_REPONAME/ $GOPATH/src/$IMPORT_PATH/
+
+test:
+  override:
+    - bash test-with-coverage.sh
+
+  post:
+    - bash <(curl -s https://codecov.io/bash)

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,154 @@
+/*
+
+This package implements our standard Logrus + Logentries + Sentry configuration.
+
+The package manages a singleton instance of logrus.Logger, initialized from environment variables.
+
+You will use it exactly as you would use logrus.
+
+
+Examples
+
+Log an info:
+
+	WithFields(logger.Fields{
+		"driverId": driverId,
+		"rideId": rideId,
+	}).Info("Ride accepted")
+
+Log an info with a single field:
+
+	WithField("userId", userId).Info("User logged in")
+
+
+Log an error:
+
+	WithFields(logger.Fields{
+		"event": event,
+		"err": err
+	}).Error("Could not store ride end event")
+
+IMPORTANT: when logging an error or a warning, don't put an error you're not sure about the message as the message.
+The reason for that is that sentry uses the message to regroup similar events. If your library returns different
+messages for different occurrences of the same problem, you will flood your team with a lot of alerts for the same
+problem. Instead, put the error in the data.
+
+
+Configuration
+
+SENTRY_DSN: If provided, warning and error logs will be sent to sentry.
+
+LOGGER_NAME - not yet implemented - The name of the logger.
+
+LOGGER_LEVEL - not yet implemented - The minimum level of the message to be actually logged.
+Possible values: "debug", "info", "warning", "error".
+
+LOGENTRIES_TOKEN - not yet implemented - If provided, logs will be sent to logentries.
+
+LOGSTASH_HOST - not yet implemented - If provided, logs will be sent to logstash.
+
+LOGSTASH_PORT - not yet implemented - Mandatory if LOGSTASH_HOST is provided.
+
+
+Notes
+
+Methods that allow logging without context are not provided, in order to discourage logging without context.
+
+ */
+package logger
+
+import (
+	"github.com/Sirupsen/logrus"
+	"os"
+	"github.com/evalphobia/logrus_sentry"
+	"time"
+)
+
+/*
+Alias for the logrus.Fields
+
+This will allow most of our code to not directly depend on logrus, making it much easier if we have to switch
+to another logger later.
+ */
+type Fields logrus.Fields
+
+var logger *logrus.Logger
+
+/*
+Creates a sentry hook catching message of level warning and worse and sending them to sentry
+ */
+func createSentryHook(sentryDns string) logrus.Hook {
+	hook, err := logrus_sentry.NewSentryHook(sentryDns, []logrus.Level{
+		logrus.PanicLevel,
+		logrus.FatalLevel,
+		logrus.ErrorLevel,
+		logrus.WarnLevel,
+	})
+	if err != nil {
+		panic(err)
+	}
+	hook.Timeout = time.Second
+	hook.StacktraceConfiguration.Enable = true
+	hook.StacktraceConfiguration.Level = logrus.ErrorLevel
+	hook.StacktraceConfiguration.Context = 12
+
+	// 4 is the magic number to use so the stack starts where logger.Error(... was used
+	hook.StacktraceConfiguration.Skip = 4
+
+	return hook
+}
+
+/*
+Returns the already configured logrus.Logger singletton.
+
+Note: this instance is cached, so if the environment changes, you will need to call ReloadConfiguration() before
+calling this method.
+ */
+func CreateLogger() *logrus.Logger {
+	newLogger := &logrus.Logger{
+		Out:       os.Stdout,
+		Formatter: new(logrus.TextFormatter),
+		Hooks:     make(logrus.LevelHooks),
+		Level:     logrus.DebugLevel,
+	}
+
+	sentryDns := os.Getenv("SENTRY_DSN")
+	if sentryDns != "" {
+		hook := createSentryHook(sentryDns)
+		newLogger.Hooks.Add(hook)
+	}
+	return newLogger
+}
+
+/*
+Returns the already configured logrus.Logger singletton.
+
+Note: this instance is cached, so if the environment changes, you will need to call ReloadConfiguration() before
+calling this method.
+ */
+func GetLogger() *logrus.Logger {
+	if logger == nil {
+		logger = CreateLogger()
+	}
+	return logger
+}
+
+/*
+Reloads configuration from the environment. Mostly useful for tests.
+ */
+func ReloadConfiguration() {
+	logger = nil
+}
+
+/*
+Shorthand for GetLogger().WithFields(fields). Use instead of logrus.WithFields.
+ */
+func WithFields(fields Fields) *logrus.Entry {
+	return GetLogger().WithFields(logrus.Fields(fields))
+}
+/*
+Shorthand for GetLogger().WithField(fields). Use instead of logrus.WithField.
+ */
+func WithField(key string, value interface{}) *logrus.Entry {
+	return GetLogger().WithField(key, value)
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,244 @@
+package logger
+
+import (
+	"testing"
+	"os"
+	"io/ioutil"
+	"github.com/stretchr/testify/assert"
+	"bytes"
+	"net/http/httptest"
+	"net/http"
+	"strings"
+	"io"
+	"encoding/base64"
+	"compress/zlib"
+	"encoding/json"
+	"github.com/getsentry/raven-go"
+)
+
+/*
+This helper function allows testing that certain things appear on the standard output
+ */
+func captureStdout(task func()) []byte {
+
+	in, out, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+
+	os.Stdout.Sync()
+	tmp := os.Stdout
+	os.Stdout = out
+	ReloadConfiguration()
+	defer (func() {
+		os.Stdout = tmp
+		ReloadConfiguration()
+	})()
+
+	task()
+
+	out.Close()
+
+	stdout, err := ioutil.ReadAll(in)
+	if err != nil {
+		panic(err)
+	}
+	return stdout
+}
+
+/*
+Tests that with the default setup, debug messages and params appear on stdout
+ */
+func TestDebug_Local(t *testing.T) {
+	stdout := captureStdout(func() {
+		WithFields(Fields{
+			"name": "str param",
+			"count": 1,
+		}).Debug("My message")
+		WithField("count", 2).Debug("My message 2")
+	})
+
+	lines := bytes.Split(stdout, []byte{'\n'})
+	assert.Len(t, lines, 3)
+
+	line1 := string(lines[0])
+	assert.Contains(t, line1, `level=debug`)
+	assert.Contains(t, line1, "My message")
+	assert.Contains(t, line1, `name="str param"`)
+	assert.Contains(t, line1, `count=1`)
+
+	line2 := string(lines[1])
+	assert.Contains(t, line1, `level=debug`)
+	assert.Contains(t, line2, "My message 2")
+	assert.Contains(t, line2, `count=2`)
+}
+
+/*
+Tests that with the default setup, info messages and params appear on stdout
+ */
+func TestInfo_Local(t *testing.T) {
+	stdout := captureStdout(func() {
+		WithFields(Fields{
+			"name": "str param",
+			"count": 1,
+		}).Info("My message")
+		WithField("count", 2).Info("My message 2")
+	})
+	lines := bytes.Split(stdout, []byte{'\n'})
+	assert.Len(t, lines, 3)
+
+	line1 := string(lines[0])
+	assert.Contains(t, line1, `level=info`)
+	assert.Contains(t, line1, "My message")
+	assert.Contains(t, line1, `name="str param"`)
+	assert.Contains(t, line1, `count=1`)
+
+	line2 := string(lines[1])
+	assert.Contains(t, line1, `level=info`)
+	assert.Contains(t, line2, "My message 2")
+	assert.Contains(t, line2, `count=2`)
+}
+
+/*
+Tests that with the default setup, error messages and params appear on stdout
+ */
+func TestError_Local(t *testing.T) {
+	stdout := captureStdout(func() {
+		WithFields(Fields{
+			"name": "str param",
+			"count": 1,
+		}).Error("My message")
+		WithField("count", 2).Error("My message 2")
+
+	})
+
+	lines := bytes.Split(stdout, []byte{'\n'})
+	assert.Len(t, lines, 3)
+
+	line1 := string(lines[0])
+	assert.Contains(t, line1, `level=error`)
+	assert.Contains(t, line1, "My message")
+	assert.Contains(t, line1, `name="str param"`)
+	assert.Contains(t, line1, `count=1`)
+
+	line2 := string(lines[1])
+	assert.Contains(t, line1, `level=error`)
+	assert.Contains(t, line2, "My message 2")
+	assert.Contains(t, line2, `count=2`)
+}
+
+/*
+Tests that with SENTRY_DSN set, info messages are *not sent* to the sentry server
+ */
+func TestError_Info(t *testing.T) {
+	oldSentryDns := os.Getenv("SENTRY_DSN")
+	defer os.Setenv("SENTRY_DSN", oldSentryDns)
+
+	handle := func(res http.ResponseWriter, req *http.Request) {
+		assert.Fail(t, "Sentry server was called for an info, which is not the intended behavior")
+	}
+
+	handler := http.HandlerFunc(handle)
+
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	testServerHost := strings.Split(ts.URL, "http://")[1]
+
+	os.Setenv("SENTRY_DSN", "http://aaa:bbb@" + testServerHost + "/123")
+	ReloadConfiguration()
+
+	WithFields(Fields{
+		"name": "str param",
+		"count": 1,
+	}).Info("My message")
+}
+
+/*
+Groups all the stuff required to make a local mock sentry server
+ */
+type TestSentryServer struct {
+	PacketChannel chan *raven.Packet
+	Server        *httptest.Server
+	Host          string
+}
+
+/*
+Starts a mock sentry server that will accept all messages, parse then and send them to a channel.
+
+Use the channel to receive messages sent to the server.
+ */
+func startMockSentryServer(t *testing.T) *TestSentryServer {
+	packetChannel := make(chan *raven.Packet, 1)
+	// inspired from
+	// https://github.com/evalphobia/logrus_sentry/blob/162fd93cca6f0b1170f1b12c980a004744297f13/sentry_test.go#L45
+	handle := func(res http.ResponseWriter, req *http.Request) {
+		defer req.Body.Close()
+		contentType := req.Header.Get("Content-Type")
+		var bodyReader io.Reader = req.Body
+		// underlying client will compress and encode payload above certain size
+		if contentType == "application/octet-stream" {
+			bodyReader = base64.NewDecoder(base64.StdEncoding, bodyReader)
+			var err error
+			bodyReader, err = zlib.NewReader(bodyReader)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+		}
+
+		d := json.NewDecoder(bodyReader)
+		p := &raven.Packet{}
+		err := d.Decode(p)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		packetChannel <- p
+	}
+
+	handler := http.HandlerFunc(handle)
+	ts := httptest.NewServer(handler)
+	testServerHost := strings.Split(ts.URL, "http://")[1]
+	return &TestSentryServer{
+		PacketChannel:packetChannel,
+		Server:ts,
+		Host:testServerHost,
+	}
+}
+/*
+Tests that with SENTRY_DSN set, error messages and params are sent to the sentry server
+ */
+func TestError_Sentry(t *testing.T) {
+	oldSentryDns := os.Getenv("SENTRY_DSN")
+	defer os.Setenv("SENTRY_DSN", oldSentryDns)
+
+	ts := startMockSentryServer(t)
+	defer ts.Server.Close()
+
+	os.Setenv("SENTRY_DSN", "http://aaa:bbb@" + ts.Host + "/123")
+	ReloadConfiguration()
+
+	WithFields(Fields{
+		"name": "str param",
+		"count": 1,
+	}).Error("My message")
+
+	packet := <-ts.PacketChannel
+
+	assert.Equal(t, raven.Severity("error"), packet.Level)
+	assert.Equal(t, "My message", packet.Message)
+	assert.Equal(t, "str param", packet.Extra["name"])
+	assert.EqualValues(t, 1, packet.Extra["count"])
+	assert.Equal(t, "go", packet.Platform)
+}
+
+/*
+Test that createSentryHook panics when an invalid sentry url is provided
+ */
+func TestCreateSentryHookInvalidUrl(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Panic did not occur")
+		}
+	}()
+	createSentryHook("Not a valid sentry URL")
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -131,8 +131,8 @@ func TestError_Local(t *testing.T) {
 Tests that with SENTRY_DSN set, info messages are *not sent* to the sentry server
  */
 func TestError_Info(t *testing.T) {
-	oldSentryDns := os.Getenv("SENTRY_DSN")
-	defer os.Setenv("SENTRY_DSN", oldSentryDns)
+	oldSentryDsn := os.Getenv("SENTRY_DSN")
+	defer os.Setenv("SENTRY_DSN", oldSentryDsn)
 
 	handle := func(res http.ResponseWriter, req *http.Request) {
 		assert.Fail(t, "Sentry server was called for an info, which is not the intended behavior")
@@ -208,8 +208,8 @@ func startMockSentryServer(t *testing.T) *TestSentryServer {
 Tests that with SENTRY_DSN set, error messages and params are sent to the sentry server
  */
 func TestError_Sentry(t *testing.T) {
-	oldSentryDns := os.Getenv("SENTRY_DSN")
-	defer os.Setenv("SENTRY_DSN", oldSentryDns)
+	oldSentryDsn := os.Getenv("SENTRY_DSN")
+	defer os.Setenv("SENTRY_DSN", oldSentryDsn)
 
 	ts := startMockSentryServer(t)
 	defer ts.Server.Close()

--- a/test-with-coverage.sh
+++ b/test-with-coverage.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+go get -t .
+
+go vet $(go list ./... | grep -v /vendor/)
+
+echo "mode: set" > coverage.txt
+
+for d in $(go list ./... | grep -v vendor); do
+    go test -v -race -coverprofile=profile.out -covermode=atomic $d
+    if [ -f profile.out ]; then
+        cat profile.out | grep -v "mode: set" >> coverage.txt
+        rm profile.out
+    fi
+done

--- a/test-with-coverage.sh
+++ b/test-with-coverage.sh
@@ -6,6 +6,9 @@ go get -t .
 
 go vet $(go list ./... | grep -v /vendor/)
 
+go get github.com/golang/lint/golint
+golint -set_exit_status $(go list ./... | grep -v /vendor/)
+
 echo "mode: set" > coverage.txt
 
 for d in $(go list ./... | grep -v vendor); do

--- a/test.sh
+++ b/test.sh
@@ -2,9 +2,13 @@
 
 set -e
 
+
 go get -t .
 
 go vet $(go list ./... | grep -v /vendor/)
+
+go get github.com/golang/lint/golint
+golint -set_exit_status $(go list ./... | grep -v /vendor/)
 
 for d in $(go list ./... | grep -v vendor); do
     go test $d

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+go get -t .
+
+go vet $(go list ./... | grep -v /vendor/)
+
+for d in $(go list ./... | grep -v vendor); do
+    go test $d
+done


### PR DESCRIPTION
Same idea as with chpr-logger: yield a ready-to-use instance of the go-to logging library (logrus here), configured with environment variables.

This initial pull request boostraps the project by adding minimal interesting functionnality:
- Send errors to sentry
- Write logs on stdout

## Why logrus ?

I looked for a benchmark of different logging libraries, and considered using those listed [here](https://github.com/uber-go/zap):
* https://github.com/uber-go/zap - Very fast and I like the approach a lot, but dismissed because it can't integrate sentry well yet
* https://github.com/Sirupsen/logrus
* https://github.com/go-kit/kit - Seems too complicated for our current need, does too much things. I don't feel like adding this as a dependency just for logging.
* https://github.com/inconshreveable/log15
* https://github.com/apex/log

Among the remaining logrus seems to be the most active and popular, and has a nice curated list of integrations, including sentry and logentries, so I picked this one.
