### PR TITLE
OPE-2342 Delete all references to Logentries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Doc below generated from godoc with godocdown (see dev-tools/test.sh)
 --
     import "github.com/transcovo/go-chpr-logger"
 
-Package logger implements our standard Logrus + Logentries + Sentry
+Package logger implements our standard Logrus + Sentry
 configuration.
 
 The package manages a singleton instance of logrus.Logger, initialized from
@@ -67,9 +67,6 @@ values: "debug" (default, convenient for development), "info", "warning" or
 be logged.
 
 LOGGER_NAME - not yet implemented - The name of the logger.
-
-LOGENTRIES_TOKEN - not yet implemented - If provided, logs will be sent to
-logentries.
 
 LOGSTASH_HOST - not yet implemented - If provided, logs will be sent to
 logstash.

--- a/logger.go
+++ b/logger.go
@@ -1,5 +1,5 @@
 /*
-Package logger implements our standard Logrus + Logentries + Sentry configuration.
+Package logger implements our standard Logrus + Sentry configuration.
 
 The package manages a singleton instance of logrus.Logger, initialized from environment variables.
 
@@ -49,8 +49,6 @@ Possible values: "debug" (default, convenient for development), "info", "warning
 is provided, "info" will be used and a warning will be logged.
 
 LOGGER_NAME - not yet implemented - The name of the logger.
-
-LOGENTRIES_TOKEN - not yet implemented - If provided, logs will be sent to logentries.
 
 LOGSTASH_HOST - not yet implemented - If provided, logs will be sent to logstash.
 


### PR DESCRIPTION
### Jira issue

https://transcovo.atlassian.net/browse/OPE-2342

### Purpose of this PR

Delete all references, code and documentation to Logentries as the service has
been replaced with ELK.

### Configuration change

Delete all variables referencing Logentries.

### Checks

- [ ] Documentation of API routes is very clear, even for a newcomer
- [ ] Documentation of database model fields and indices are very clear, even for a newcomer
- [ ] Documentation of environment variables is very clear, even for a newcomer
- [ ] All relevant usecases of are tested
- [ ] These changes won't cause memory / CPU problems even if business grows by a factor of 100
- [ ] It's ok if these changes go to production and then are rolled-back


### Linked PRs:

- ...
