### PR TITLE
TECH Support standard SENTRY_ENVIRONMENT value

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -44,6 +44,8 @@ Configuration
 
 SENTRY_DSN: If provided, warning and error logs will be sent to sentry.
 
+SENTRY_ENVIRONMENT: If provided, used to identify the error or warning log source.
+
 LOGGER_LEVEL: The minimum level of the message to be actually logged.
 Possible values: "debug" (default, convenient for development), "info", "warning" or "error". If an invalid value
 is provided, "info" will be used and a warning will be logged.
@@ -59,24 +61,25 @@ Notes
 
 Methods that allow logging without context are not provided, in order to discourage logging without context.
 
- */
+*/
 package logger
 
 import (
-	"github.com/sirupsen/logrus"
-	"os"
-	"github.com/evalphobia/logrus_sentry"
-	"time"
-	"strings"
 	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/evalphobia/logrus_sentry"
+	"github.com/sirupsen/logrus"
 )
 
 var logger *logrus.Logger
 
 /*
 Creates a sentry hook catching message of level warning or worse and sending them to sentry
- */
-func createSentryHook(sentryDsn string) logrus.Hook {
+*/
+func createSentryHook(sentryDsn, environment string) logrus.Hook {
 	hook, err := logrus_sentry.NewSentryHook(sentryDsn, []logrus.Level{
 		logrus.PanicLevel,
 		logrus.FatalLevel,
@@ -89,6 +92,9 @@ func createSentryHook(sentryDsn string) logrus.Hook {
 	hook.Timeout = time.Second
 	hook.StacktraceConfiguration.Enable = true
 	hook.StacktraceConfiguration.Level = logrus.ErrorLevel
+
+	// Set the Sentry Raven client environment
+	hook.SetEnvironment(environment)
 
 	// Number of lines of context code displayed around each line of the stack trace. 12 is a comfortable
 	// amount, and there is no need to make this configurable for now. We can change it later.
@@ -111,7 +117,7 @@ the situation
 
 Note: we do not use logrus.ParseLevel because we want to exclude warn, fatal and panic which are not a part of cp
 conventions, and we need to have error messages consistent with what's actually possible.
- */
+*/
 func getLevelFromEnv() (logrus.Level, error) {
 	levelStr := os.Getenv("LOGGER_LEVEL")
 	if levelStr == "" {
@@ -135,7 +141,7 @@ func getLevelFromEnv() (logrus.Level, error) {
 /*
 CreateLogger creates a new instance of logrus.Logger, which is configured from the environment variables according to cp
 conventions (see package overview)
- */
+*/
 func CreateLogger() *logrus.Logger {
 	level, levelParseErr := getLevelFromEnv()
 	// levelParseErr is handled at the end of this function, because the handling is logging a warning, and
@@ -150,7 +156,9 @@ func CreateLogger() *logrus.Logger {
 
 	sentryDsn := os.Getenv("SENTRY_DSN")
 	if sentryDsn != "" {
-		hook := createSentryHook(sentryDsn)
+		sentryEnvironment := os.Getenv("SENTRY_ENVIRONMENT")
+		hook := createSentryHook(sentryDsn, sentryEnvironment)
+
 		newLogger.Hooks.Add(hook)
 	}
 
@@ -166,7 +174,7 @@ GetLogger returns logrus.Logger singleton, already configured and ready to use.
 
 This instance is cached, so if the environment changes, you will need to call ReloadConfiguration() to take changes
 into account.
- */
+*/
 func GetLogger() *logrus.Logger {
 	if logger == nil {
 		logger = CreateLogger()
@@ -176,40 +184,41 @@ func GetLogger() *logrus.Logger {
 
 /*
 ReloadConfiguration reloads configuration from the environment. Mostly useful for tests.
- */
+*/
 func ReloadConfiguration() {
 	logger = nil
 }
 
 /*
 WithFields is a shorthand for GetLogger().WithFields(fields). Use instead of logrus.WithFields.
- */
+*/
 func WithFields(fields logrus.Fields) *logrus.Entry {
 	return GetLogger().WithFields(logrus.Fields(fields))
 }
+
 /*
 WithField is a shorthand for GetLogger().WithField(fields). Use instead of logrus.WithField.
- */
+*/
 func WithField(key string, value interface{}) *logrus.Entry {
 	return GetLogger().WithField(key, value)
 }
 
 /*
 Debug is a shorthand to GetLogger().Debug
- */
+*/
 var Debug = GetLogger().Debug
 
 /*
 Info is a shorthand to GetLogger().Info
- */
+*/
 var Info = GetLogger().Info
 
 /*
 Warning is a shorthand to GetLogger().Warning
- */
+*/
 var Warning = GetLogger().Warning
 
 /*
 Error is a shorthand to GetLogger().Error
- */
+*/
 var Error = GetLogger().Error

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,25 +1,26 @@
 package logger
 
 import (
-	"testing"
-	"os"
-	"io/ioutil"
-	"github.com/stretchr/testify/assert"
 	"bytes"
-	"net/http/httptest"
-	"net/http"
-	"strings"
-	"io"
-	"encoding/base64"
 	"compress/zlib"
+	"encoding/base64"
 	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
 	"github.com/getsentry/raven-go"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 /*
 This helper function allows testing that certain things appear on the standard output
- */
+*/
 func captureStdout(task func()) []byte {
 
 	in, out, err := os.Pipe()
@@ -54,7 +55,7 @@ changed
 key is the name of the environment variable to change
 value is the temporary value
 task specifies the task to execute
- */
+*/
 func withEnvVariable(key string, value string, task func()) {
 	oldValue := os.Getenv(key)
 	defer os.Setenv(key, oldValue)
@@ -65,11 +66,11 @@ func withEnvVariable(key string, value string, task func()) {
 
 /*
 Tests that with the default setup, debug messages and params appear on stdout
- */
+*/
 func TestDebug_Local(t *testing.T) {
 	stdout := captureStdout(func() {
 		WithFields(logrus.Fields{
-			"name": "str param",
+			"name":  "str param",
 			"count": 1,
 		}).Debug("test debug")
 		WithField("count", 2).Debug("test debug 2")
@@ -125,6 +126,7 @@ func TestDebug_Local_InvalidLevel(t *testing.T) {
 		assert.Contains(t, string(stdout), "an info")
 	})
 }
+
 /*
 Tests that getLevelFromEnv return the expected value with correct input
 */
@@ -150,6 +152,7 @@ func TestGetLevelFromEnv(t *testing.T) {
 		assert.Equal(t, logrus.ErrorLevel, level)
 	})
 }
+
 /*
 Tests that when level to an invalid value that is a logrus level, it falls back to info after logging a warning
 */
@@ -170,13 +173,14 @@ func TestGetLevelFromEnv_InvalidLogrus(t *testing.T) {
 		assert.Equal(t, logrus.InfoLevel, level)
 	})
 }
+
 /*
 Tests that with the default setup, info messages and params appear on stdout
- */
+*/
 func TestInfo_Local(t *testing.T) {
 	stdout := captureStdout(func() {
 		WithFields(logrus.Fields{
-			"name": "str param",
+			"name":  "str param",
 			"count": 1,
 		}).Info("test info")
 		WithField("count", 2).Info("test info 2")
@@ -198,11 +202,11 @@ func TestInfo_Local(t *testing.T) {
 
 /*
 Tests that with the default setup, error messages and params appear on stdout
- */
+*/
 func TestError_Local(t *testing.T) {
 	stdout := captureStdout(func() {
 		WithFields(logrus.Fields{
-			"name": "str param",
+			"name":  "str param",
 			"count": 1,
 		}).Error("test error")
 		WithField("count", 2).Error("test error 2")
@@ -226,7 +230,7 @@ func TestError_Local(t *testing.T) {
 
 /*
 Tests that with SENTRY_DSN set, info messages are *not sent* to the sentry server
- */
+*/
 func TestError_Info(t *testing.T) {
 	handle := func(res http.ResponseWriter, req *http.Request) {
 		assert.Fail(t, "Sentry server was called for an info, which is not the intended behavior")
@@ -239,9 +243,9 @@ func TestError_Info(t *testing.T) {
 
 	testServerHost := strings.Split(ts.URL, "http://")[1]
 
-	withEnvVariable("SENTRY_DSN", "http://aaa:bbb@" + testServerHost + "/123", func() {
+	withEnvVariable("SENTRY_DSN", "http://aaa:bbb@"+testServerHost+"/123", func() {
 		WithFields(logrus.Fields{
-			"name": "str param",
+			"name":  "str param",
 			"count": 1,
 		}).Info("test sentry error")
 	})
@@ -250,7 +254,7 @@ func TestError_Info(t *testing.T) {
 
 /*
 Groups all the stuff required to make a local mock sentry server
- */
+*/
 type TestSentryServer struct {
 	PacketChannel chan *raven.Packet
 	Server        *httptest.Server
@@ -261,7 +265,7 @@ type TestSentryServer struct {
 Starts a mock sentry server that will accept all messages, parse then and send them to a channel.
 
 Use the channel to receive messages sent to the server.
- */
+*/
 func startMockSentryServer(t *testing.T) *TestSentryServer {
 	packetChannel := make(chan *raven.Packet, 1)
 	// inspired from
@@ -293,23 +297,24 @@ func startMockSentryServer(t *testing.T) *TestSentryServer {
 	ts := httptest.NewServer(handler)
 	testServerHost := strings.Split(ts.URL, "http://")[1]
 	return &TestSentryServer{
-		PacketChannel:packetChannel,
-		Server:ts,
-		Host:testServerHost,
+		PacketChannel: packetChannel,
+		Server:        ts,
+		Host:          testServerHost,
 	}
 }
+
 /*
 Tests that with SENTRY_DSN set, error messages and params are sent to the sentry server
- */
+*/
 func TestError_Sentry(t *testing.T) {
 	ts := startMockSentryServer(t)
 	defer ts.Server.Close()
 
-	withEnvVariable("SENTRY_DSN", "http://aaa:bbb@" + ts.Host + "/123", func() {
+	withEnvVariable("SENTRY_DSN", "http://aaa:bbb@"+ts.Host+"/123", func() {
 		ReloadConfiguration()
 
 		WithFields(logrus.Fields{
-			"name": "str param",
+			"name":  "str param",
 			"count": 1,
 		}).Error("test sentry error")
 	})
@@ -324,12 +329,12 @@ func TestError_Sentry(t *testing.T) {
 
 /*
 Test that createSentryHook panics when an invalid sentry url is provided
- */
+*/
 func TestCreateSentryHookInvalidUrl(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {
 			t.Error("Panic did not occur")
 		}
 	}()
-	createSentryHook("Not a valid sentry URL")
+	createSentryHook("Not a valid sentry URL", "")
 }


### PR DESCRIPTION
Supports the Sentry environment variable: `SENTRY_ENVIRONMENT`

![selection_391](https://user-images.githubusercontent.com/886331/32888553-e9c28034-cac7-11e7-8e02-231d86c15359.png)
